### PR TITLE
Add RRSet support for wildcards

### DIFF
--- a/certbot_plugin_gandi/gandi_api.py
+++ b/certbot_plugin_gandi/gandi_api.py
@@ -56,6 +56,18 @@ def _get_relative_name(base_domain, name):
     return name[:-len(suffix)] if name.endswith(suffix) else None
 
 
+def _get_txt_record(cfg, base_domain, relative_name):
+    response = _request(cfg, 'GET', ['zones', base_domain.zone_uuid, 'records', relative_name, 'TXT'])
+    if not response.ok:
+        return []
+    zone = _get_json(response)
+    vals = zone.get('rrset_values')
+    if vals:
+        return vals
+    else:
+        return []
+
+
 def _del_txt_record(cfg, base_domain, relative_name):
     return _request(cfg, 'DELETE', ('zones', base_domain.zone_uuid, 'records', relative_name, 'TXT'))
 
@@ -77,10 +89,14 @@ def _update_record(cfg, domain, name, request_runner):
 def add_txt_record(cfg, domain, name, value):
 
     def requester(base_domain, relative_name):
-        _del_txt_record(cfg, base_domain, relative_name)
+        existing = _get_txt_record(cfg, base_domain, relative_name)
+        to_add = [value] + existing
+        if existing:
+            _del_txt_record(cfg, base_domain, relative_name)
+
         return _request(cfg, 'POST',
                         ('zones', base_domain.zone_uuid, 'records', relative_name, 'TXT'),
-                        json={'rrset_values': [value]})
+                        json={'rrset_values': to_add})
 
     return _update_record(cfg, domain, name, requester)
 

--- a/certbot_plugin_gandi/gandi_api.py
+++ b/certbot_plugin_gandi/gandi_api.py
@@ -68,8 +68,9 @@ def _get_txt_record(cfg, base_domain, relative_name):
         return []
 
 
-def _del_txt_record(cfg, base_domain, relative_name):
-    return _request(cfg, 'DELETE', ('zones', base_domain.zone_uuid, 'records', relative_name, 'TXT'))
+def _update_txt_record(cfg, base_domain, relative_name, rrset):
+    return _request(cfg, 'PUT', ['zones', base_domain.zone_uuid, 'records', relative_name, 'TXT'],
+                                json={'rrset_values': rrset})
 
 
 def _update_record(cfg, domain, name, request_runner):
@@ -89,22 +90,18 @@ def _update_record(cfg, domain, name, request_runner):
 def add_txt_record(cfg, domain, name, value):
 
     def requester(base_domain, relative_name):
-        existing = _get_txt_record(cfg, base_domain, relative_name)
-        to_add = [value] + existing
-        if existing:
-            _del_txt_record(cfg, base_domain, relative_name)
-
-        return _request(cfg, 'POST',
-                        ('zones', base_domain.zone_uuid, 'records', relative_name, 'TXT'),
-                        json={'rrset_values': to_add})
+        rrset = [value] + _get_txt_record(cfg, base_domain, relative_name)
+        return _update_txt_record(cfg, base_domain, relative_name, rrset)
 
     return _update_record(cfg, domain, name, requester)
 
 
-def del_txt_record(cfg, domain, name):
+def del_txt_record(cfg, domain, name, value):
 
     def requester(base_domain, relative_name):
-        return _del_txt_record(cfg, base_domain, relative_name)
+        existing = _get_txt_record(cfg, base_domain, relative_name)
+        rrset = filter(lambda rr: rr.strip('"') != value, existing)
+        return _update_txt_record(cfg, base_domain, relative_name, rrset)
 
     return _update_record(cfg, domain, name, requester)
 

--- a/certbot_plugin_gandi/main.py
+++ b/certbot_plugin_gandi/main.py
@@ -51,7 +51,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
 
     def _cleanup(self, domain, validation_name, validation):
-        error = gandi_api.del_txt_record(self._get_gandi_config(), domain, validation_name)
+        error = gandi_api.del_txt_record(self._get_gandi_config(), domain, validation_name, validation)
         if error is not None:
             logger.warn('Unable to find or delete the DNS TXT record: %s', error)
 


### PR DESCRIPTION
Previously, the plugin would blow away existing TXT records for the
same DNS name when adding a TXT record. This means that issuing a
certificate for both a base domain and its wildcard could not succeed.

I noticed that your README mentions wildcard support already, but as far as I can tell, it doesn't seem to actually work. For example, in a typical wildcard scenario:

1. `_acme-challenge.example.org 360 IN TXT "xxxx"` is added via `_add_txt_record` (which calls `_del_txt_record`, wiping out all previous values).
2. `_acme-challenge.example.org 360 IN TXT "yyyy"` is added via `_add_txt_record` (which calls `_del_txt_record`, wiping out all previous values).
3. Certbot submits the challenges to the CA - the CA can only see `yyyy` because `xxxx` was deleted in (2). Challenge fails.

After this PR, existing TXT values are not removed in `_add_txt_record`.

Reported at https://community.letsencrypt.org/t/wildcard-certificate-not-renewed/87698