### PR TITLE
Add a deprecation warning to follow certbot deprecation.

### DIFF
--- a/certbot_plugin_gandi/main.py
+++ b/certbot_plugin_gandi/main.py
@@ -19,8 +19,15 @@ class Authenticator(dns_common.DNSAuthenticator):
     description = 'Obtain certificates using a DNS TXT record (if you are using Gandi for DNS).'
 
 
-    def __init__(self, *args, **kwargs):
-        super(Authenticator, self).__init__(*args, **kwargs)
+    def __init__(self, config, name, **kwargs):
+        if name in ("dns", "certbot-plugin-gandi:dns"):
+            logger.warning("""Certbot is moving to remove 3rd party plugins prefixes.
+
+Please use --authenticator dns-gandi --dns-gandi-credentials
+
+See: https://github.com/certbot/certbot/pull/8131
+""")
+        super(Authenticator, self).__init__(config, name, **kwargs)
         self.credentials = None
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     entry_points={
         'certbot.plugins': [
             'dns = certbot_plugin_gandi.main:Authenticator',
+            'dns-gandi = certbot_plugin_gandi.main:Authenticator',
         ],
     },
     classifiers=[


### PR DESCRIPTION
Closes #23 

This is what it gives with the old prefixed syntax (note that it still works, but there's the two warnings):

```
$ certbot certonly --cert-name example.com -n --agree-tos -d example.com -m admin@example.com --authenticator certbot-plugin-gandi:dns --certbot-plugin-gandi:dns-credentials /etc/gandi.ini --rsa-key-size 4096 --logs-dir ./ --work-dir ./ --config-dir ./
Saving debug log to /home/mdk/clones/certbot/letsencrypt.log
Plugin legacy name certbot-plugin-gandi:dns may be removed in a future version. Please use dns instead.
Certbot is moving to remove 3rd party plugins prefixes.

Please use --authenticator dns-gandi --dns-gandi-credentials

See: https://github.com/certbot/certbot/pull/8131

Plugins selected: Authenticator certbot-plugin-gandi:dns, Installer None
```

This is what it gives with the new unprefixed syntax, but the old plugin name (note that it still works, single warning):

```
$ certbot certonly --cert-name example.com -n --agree-tos -d example.com -m admin@example.com --authenticator dns --dns-credentials /etc/gandi.ini --rsa-key-size 4096 --logs-dir ./ --work-dir ./ --config-dir ./
Saving debug log to /home/mdk/clones/certbot/letsencrypt.log
Certbot is moving to remove 3rd party plugins prefixes.

Please use --authenticator dns-gandi --dns-gandi-credentials

See: https://github.com/certbot/certbot/pull/8131

Plugins selected: Authenticator dns, Installer None
```

This is what it gives with the new syntax (no warnings):

```
$ certbot certonly --cert-name example.com -n --agree-tos -d example.com -m admin@example.com --authenticator dns-gandi --dns-gandi-credentials /etc/gandi.ini --rsa-key-size 4096 --logs-dir ./ --work-dir ./ --config-dir ./
Saving debug log to /home/mdk/clones/certbot/letsencrypt.log

Plugins selected: Authenticator dns-gandi, Installer None
```

