### PR TITLE
Fix API call for new Gandi API

### DIFF
--- a/certbot_plugin_gandi/gandi_api.py
+++ b/certbot_plugin_gandi/gandi_api.py
@@ -26,12 +26,12 @@ def _get_response_message(response, default='<No reason given>'):
 def _headers(cfg):
     return {
         'Content-Type': 'application/json',
-        'X-Api-Key': cfg.api_key
+        'Authorization': 'Apikey ' + cfg.api_key
     }
 
 
 def _get_url(*segs):
-    return 'https://dns.api.gandi.net/api/v5/{}'.format('/'.join(segs))
+    return 'https://api.gandi.net/v5/livedns/{}'.format('/'.join(segs))
 
 def _request(cfg, method, segs, **kw):
     headers = _headers(cfg)


### PR DESCRIPTION
I tried using this plugin via the Debian package repositories but it
kept erroring. Further investigation showed that the base URL used in
this script was incorrect, as Gandi have made upstream changes.

This commit changes the URL to the new one and amends the authentication
system to match. I was able to renew my certificates using this amended
script.

Fixes #19.