### PR TITLE
Fix compatibility with Certbot < v2.0.0 & Certbot >= 2.1.0

### DIFF
--- a/certbot_plugin_gandi/main.py
+++ b/certbot_plugin_gandi/main.py
@@ -1,8 +1,7 @@
-import zope.interface
 import logging
 import uuid
 
-from certbot import interfaces, errors
+from certbot import errors
 from certbot.plugins import dns_common
 
 from . import gandi_api
@@ -11,8 +10,6 @@ from . import gandi_api
 logger = logging.getLogger(__name__)
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for Gandi (using LiveDNS)."""
 

--- a/certbot_plugin_gandi/main.py
+++ b/certbot_plugin_gandi/main.py
@@ -9,7 +9,16 @@ from . import gandi_api
 
 logger = logging.getLogger(__name__)
 
+def try_registration(cls):
+    try:
+        interfaces.Installer.register(cls)
+    except AttributeError:
+        pass
+    return cls 
 
+@try_registration
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for Gandi (using LiveDNS)."""
 

--- a/certbot_plugin_gandi/main.py
+++ b/certbot_plugin_gandi/main.py
@@ -10,6 +10,7 @@ from . import gandi_api
 
 logger = logging.getLogger(__name__)
 
+
 def try_registration(cls):
     try:
         interfaces.Installer.register(cls)

--- a/certbot_plugin_gandi/main.py
+++ b/certbot_plugin_gandi/main.py
@@ -11,16 +11,16 @@ from . import gandi_api
 logger = logging.getLogger(__name__)
 
 
-def try_registration(cls):
+def register_authenticator(cls):
     try:
-        interfaces.Installer.register(cls)
+        interfaces.Authenticator.register(cls)
     except AttributeError:
         pass
+    zope.interface.implementer(interfaces.IAuthenticator)(cls) 
+    zope.interface.provider(interfaces.IPluginFactory)(cls)
     return cls 
-
-@try_registration
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
+    
+@register_authenticator
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for Gandi (using LiveDNS)."""
 

--- a/certbot_plugin_gandi/main.py
+++ b/certbot_plugin_gandi/main.py
@@ -1,7 +1,8 @@
+import zope.interface
 import logging
 import uuid
 
-from certbot import errors
+from certbot import interfaces, errors
 from certbot.plugins import dns_common
 
 from . import gandi_api

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     python_requires=' >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=[
         'certbot',
+        'zope.interface',
         'requests>=2.4.2',
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
     python_requires=' >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=[
         'certbot',
-        'zope.interface',
         'requests>=2.4.2',
     ],
     entry_points={


### PR DESCRIPTION
You can see other plugins doing the fix for certbot 2.0 compatibility : https://github.com/domeneshop/certbot-dns-domeneshop/commit/bf8e57594a9aaa5de5175fd0c7c7fbc990623206

Otherwise, when using Certbot >= 2.0, you would get:

> An unexpected error occurred:
AttributeError: module 'certbot.interfaces' has no attribute 'IAuthenticator'

It would be great to merge ;)
And release the next 1.4.2 version.

Thanks!