### PR TITLE
Add Ubuntu distribution channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ PyPI is the upstream distribution channel, other channels are not maintained by 
 * PyPI: https://pypi.org/project/certbot-plugin-gandi/
 * Archlinux: https://aur.archlinux.org/packages/certbot-dns-gandi-git/
 * Debian: https://packages.debian.org/sid/main/python3-certbot-dns-gandi
+* Ubuntu: https://packages.ubuntu.com/kinetic/python3-certbot-dns-gandi
 
-Every release pushed to PyPI is signed with GPG.
+Latests builds are also available on Launchpad: https://launchpad.net/ubuntu/+source/python-certbot-dns-gandi
 
 ## Wildcard certificates
 


### PR DESCRIPTION
Ubuntu supports your package `certbot-dns-gandi`.

I advise https://github.com/obynio/certbot-plugin-gandi/issues/22 to be closed.
For these reasons:
 - The Ubuntu packaging guide does not recommend snap crafting but deb packaging: https://packaging.ubuntu.com/html/packaging-new-software.html ;
 - Ubuntu MOTU Developers maintain a `certbot-dns-gandi` deb package: https://packages.ubuntu.com/kinetic/python3-certbot-dns-gandi ;
 - This package is actively maintained with the latest version available on the latest Ubuntu: https://launchpad.net/ubuntu/+source/python-certbot-dns-gandi/1.4.2-1
 - Only Ubuntu Core, a special Ubuntu spin-off for the IoT, is solely using snap packages ;
 - The Ubuntu main flavours use both apt & snap and the main Ubuntu packaging policy only gives direct guidance for deb/apt packaging ;
 - We are years away for snap replacing apt as [default package manager](https://blueprints.launchpad.net/ubuntu/+spec/package-management-default-snap).

If a snap package is built by a third-party maintainer for `certbot-dns-gandi`, you can accept a PR updating the README file such as:

```
* PyPI: https://pypi.org/project/certbot-plugin-gandi/
* Archlinux: https://aur.archlinux.org/packages/certbot-dns-gandi-git/
* Debian: https://packages.debian.org/sid/main/python3-certbot-dns-gandi
* Ubuntu: https://packages.ubuntu.com/kinetic/python3-certbot-dns-gandi
* Ubuntu (snap): https://snapcraft.io/certbot-dns-gandi (does not exist yet)
```
Until a third-party maintainer decides to craft and publish an Ubuntu `certbot-dns-gandi` snap package, the [official package for Ubuntu](https://packages.ubuntu.com/kinetic/python3-certbot-dns-gandi
) should be the only recommended way.