### PR TITLE
remove unused six import

### DIFF
--- a/certbot_plugin_gandi/gandi_api.py
+++ b/certbot_plugin_gandi/gandi_api.py
@@ -1,5 +1,4 @@
 import requests
-import six
 
 from collections import namedtuple
 from certbot.plugins import dns_common
@@ -107,5 +106,3 @@ def del_txt_record(cfg, domain, name, value):
         return _update_txt_record(cfg, base_domain, relative_name, rrset)
 
     return _update_record(cfg, domain, name, requester)
-
-


### PR DESCRIPTION
fixes #49

It seems the certbot Docker image recently removed the six library, and now the certbot-plugin-gandi crashes due to this unused import statement.