### PR TITLE
Bump deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 
 dependencies = [
-    "certbot>=2.4.0,<4",
+    "certbot>=2.4.0,<6",
     "requests>=2.32.3,<3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Security",
     "Topic :: System :: Installation/Setup",


### PR DESCRIPTION
Certbot recently released version 5, so the plugin did no longer install cleanly due to the upper limit on the dependency.